### PR TITLE
Restructure the pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,9 @@ import { IonReactRouter } from '@ionic/react-router';
 import React from 'react';
 import { Redirect, Route } from 'react-router-dom';
 
+import Menu from './components/Menu';
 import Home from './pages/Home';
+import Map from './pages/Map';
 
 /* Core CSS required for Ionic components to work properly */
 /* Basic CSS for apps built with Ionic */
@@ -24,8 +26,10 @@ import Home from './pages/Home';
 const App = () => (
    <IonApp>
       <IonReactRouter>
-         <IonRouterOutlet>
-            <Route path='/home' component={Home} exact={true} />
+         <Menu />
+         <IonRouterOutlet id='main-outlet'>
+            <Route path='/home' component={Home} exact />
+            <Route path='/map' component={Map} exact />
             <Route exact path='/' render={() => <Redirect to='/home' />} />
          </IonRouterOutlet>
       </IonReactRouter>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,24 @@
+import { IonButtons, IonHeader, IonMenuButton, IonTitle, IonToolbar } from '@ionic/react';
+import React from 'react';
+
+class Header extends React.Component {
+   render() {
+      return (
+         <IonHeader translucent='true'>
+            <IonToolbar>
+               <IonButtons slot='start'>
+                  <IonMenuButton
+                     autoHide='false'
+                     fill='clear'
+                     color='dark'
+                     slot='start'
+                  />
+               </IonButtons>
+               <IonTitle>World Expo 2020</IonTitle>
+            </IonToolbar>
+         </IonHeader>
+      );
+   }
+}
+
+export default Header;

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -1,0 +1,41 @@
+import { IonContent, IonItem, IonList, IonMenu, IonMenuToggle } from '@ionic/react';
+import React from 'react';
+import { withRouter } from 'react-router';
+
+const pages = [
+   { title: 'Home', path: '/home' },
+   { title: 'Map', path: '/map' }
+];
+
+export class Menu extends React.Component {
+   navigateToPage = page => {
+      this.props.history.push(page);
+   };
+
+   renderMenuItems = () => {
+      return pages.map(page => (
+         <IonMenuToggle key={page.title}>
+            <IonItem onClick={() => this.navigateToPage(page.path)}>
+               {page.title}
+            </IonItem>
+         </IonMenuToggle>
+      ));
+   };
+
+   render() {
+      return (
+         <IonMenu
+            side='start'
+            type='overlay'
+            menuId='side-nav'
+            contentId='main-outlet'
+         >
+            <IonContent>
+               <IonList>{this.renderMenuItems()}</IonList>
+            </IonContent>
+         </IonMenu>
+      );
+   }
+}
+
+export default withRouter(Menu);

--- a/src/pages/Map.jsx
+++ b/src/pages/Map.jsx
@@ -3,17 +3,17 @@ import React from 'react';
 
 import Header from '../components/Header';
 
-class Home extends React.Component {
+class Map extends React.Component {
    render() {
       return (
          <IonPage>
             <Header />
             <IonContent class='ion-padding'>
-               <h1>Home</h1>
+               <h1>Map</h1>
             </IonContent>
          </IonPage>
       );
    }
 }
 
-export default Home;
+export default Map;


### PR DESCRIPTION
For react router to work in Ionic, you need to have an IonPage for the  component that's being rendered via the route.

IonHeader also needs to be a direct sibling to IonContent to be styled correctly in the layout.