### PR TITLE
Restructure the pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import '@ionic/react/css/text-alignment.css';
 import '@ionic/react/css/text-transformation.css';
 import '@ionic/react/css/typography.css';
 
-import { IonApp, IonButtons, IonHeader, IonMenuButton, IonRouterOutlet, IonTitle, IonToolbar } from '@ionic/react';
+import { IonApp, IonRouterOutlet } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
 import React from 'react';
 import { Redirect, Route } from 'react-router-dom';
@@ -27,22 +27,9 @@ const App = props => (
    <IonApp>
       <IonReactRouter>
          <Menu />
-         <IonHeader>
-            <IonToolbar>
-               <IonButtons slot='start'>
-                  <IonMenuButton
-                     autoHide='false'
-                     fill='clear'
-                     color='dark'
-                     slot='start'
-                  />
-               </IonButtons>
-               <IonTitle>World Expo 2020</IonTitle>
-            </IonToolbar>
-         </IonHeader>
          <IonRouterOutlet id='main-outlet'>
-            <Route path='/home' component={Home} exact={true} />
-            <Route path='/map' component={Map} exact={true} />
+            <Route path='/home' component={Home} exact />
+            <Route path='/map' component={Map} exact />
             <Route exact path='/' render={() => <Redirect to='/home' />} />
          </IonRouterOutlet>
       </IonReactRouter>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,24 @@
+import { IonButtons, IonHeader, IonMenuButton, IonTitle, IonToolbar } from '@ionic/react';
+import React from 'react';
+
+class Header extends React.Component {
+   render() {
+      return (
+         <IonHeader translucent='true'>
+            <IonToolbar>
+               <IonButtons slot='start'>
+                  <IonMenuButton
+                     autoHide='false'
+                     fill='clear'
+                     color='dark'
+                     slot='start'
+                  />
+               </IonButtons>
+               <IonTitle>World Expo 2020</IonTitle>
+            </IonToolbar>
+         </IonHeader>
+      );
+   }
+}
+
+export default Header;

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { withRouter } from 'react-router';
 
 const pages = [
-   { title: 'Home', path: '/' },
+   { title: 'Home', path: '/home' },
    { title: 'Map', path: '/map' }
 ];
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,12 +1,17 @@
-import { IonContent } from '@ionic/react';
+import { IonContent, IonPage } from '@ionic/react';
 import React from 'react';
+
+import Header from '../components/Header';
 
 class Home extends React.Component {
    render() {
       return (
-         <IonContent padding className='ion-padding'>
-            <h1>Home</h1>
-         </IonContent>
+         <IonPage>
+            <Header />
+            <IonContent class='ion-padding'>
+               <h1>Home</h1>
+            </IonContent>
+         </IonPage>
       );
    }
 }


### PR DESCRIPTION
For react router to work in Ionic, you need to have an IonPage for the  component that's being rendered via the route.

IonHeader also needs to be a direct sibling to IonContent to be styled correctly in the layout.